### PR TITLE
change google maps protocol

### DIFF
--- a/index.md
+++ b/index.md
@@ -20,9 +20,9 @@ Hacker Breakfast takes place at [Revel 77 Coffee](http://www.revel77coffee.com/)
 > 3223 E 57th Ave Suite K<br>
 > Spokane, WA  99223-6010
 
-[Get Directions](https://maps.google.com/maps?ie=UTF8&cid=693353392549540379&q=Revel+77+Coffee&gl=US&hl=en&t=m&z=15&vpsrc=0&iwloc=A&f=d&daddr=Revel+77+Coffee,+3223+East+57th+Avenue,+Spokane,+WA+99223&geocode=%3BCen4sUGhQM2CFWNa1gIdVi4B-SlvshVKBiOeVDEbMrqqPEmfCQ)
+[Get Directions](http://maps.google.com/maps?ie=UTF8&cid=693353392549540379&q=Revel+77+Coffee&gl=US&hl=en&t=m&z=15&vpsrc=0&iwloc=A&f=d&daddr=Revel+77+Coffee,+3223+East+57th+Avenue,+Spokane,+WA+99223&geocode=%3BCen4sUGhQM2CFWNa1gIdVi4B-SlvshVKBiOeVDEbMrqqPEmfCQ)
 
-<p><iframe width="650" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://maps.google.com/maps?ie=UTF8&amp;cid=693353392549540379&amp;q=Revel+77+Coffee&amp;gl=US&amp;hl=en&amp;t=m&amp;ll=47.606134,-117.359862&amp;spn=0.010127,0.027895&amp;z=15&amp;iwloc=A&amp;output=embed">&nbsp;</iframe></p>
+<p><iframe width="650" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="http://maps.google.com/maps?ie=UTF8&amp;cid=693353392549540379&amp;q=Revel+77+Coffee&amp;gl=US&amp;hl=en&amp;t=m&amp;ll=47.606134,-117.359862&amp;spn=0.010127,0.027895&amp;z=15&amp;iwloc=A&amp;output=embed">&nbsp;</iframe></p>
 
 ### Contact
 


### PR DESCRIPTION
Google maps protocol is https and site is served via http. Browser complains about mismatching protocols.
